### PR TITLE
add Accept-Language header en-Us

### DIFF
--- a/tweets.go
+++ b/tweets.go
@@ -78,6 +78,7 @@ func FetchTweets(user string, last string) ([]*Tweet, error) {
 	req.Header.Set("Referer", "https://twitter.com/"+user)
 	req.Header.Set("Accept", "application/json, text/javascript, */*; q=0.01")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8")
+	req.Header.Set("Accept-Language", "en-US")
 	req.Header.Set("X-Twitter-Active-User", "yes")
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 


### PR DESCRIPTION
I didn't understand why there was a problem getting the replies and likes of each tweet. The problem did not happen with retweets.

`s.Find(".ProfileTweet-actionCount").Each(func(i int, c *goquery.Selection) {
				txt := strings.TrimSpace(c.Text())
				if strings.HasSuffix(txt, "likes") {
					l := strings.Split(txt, " ")
					tweet.Likes, _ = strconv.Atoi(l[0])
				} else if strings.HasSuffix(txt, "replies") {
					l := strings.Split(txt, " ")
					tweet.Replies, _ = strconv.Atoi(l[0])
				} else if strings.HasSuffix(txt, "retweets") {
					l := strings.Split(txt, " ")
					tweet.Retweets, _ = strconv.Atoi(l[0])
				}
			})`
Reviewing I have found that where I expected to find "replies" or "likes" I found "respuestas" or "Me gustas", the same text in Spanish, changing this line it seems that you make sure of the locale in English and it works.