### PR TITLE
Fix image grids not being recognized as photos

### DIFF
--- a/tweets.go
+++ b/tweets.go
@@ -174,6 +174,11 @@ func readTweetsFromHTML(htm *strings.Reader) ([]*Tweet, error) {
 					tweet.Photos = append(tweet.Photos, link+"?format=jpg&name=large")
 				}
 			})
+			s.Find(".CroppedImage-image").Each(func(i int, p *goquery.Selection) {
+				if link, ok := p.Attr("data-image"); ok {
+					tweet.Photos = append(tweet.Photos, link+"?format=jpg&name=large")
+				}
+			})
 			// s.Find(".PlayableMedia-player").Each(func(i int, v *goquery.Selection) {
 			// 	if style, ok := v.Attr("style"); ok {
 			// 		if strings.Contains(style, "background") {


### PR DESCRIPTION
Hi! First of all, thank you for keeping an up-to-date scraper!

Image galleries were not listed among photos. For my use case, this was crucial. Thankfully, the code was simple enough for me to be able to fix it even knowing zero Go.

For a reproducer, look at https://twitter.com/axiomverge. Without the provided fix, all the top tweets have no photos listed, but with it, the photos are included.