### PR TITLE
change order by timeline.Instructions to order by time.

### DIFF
--- a/types.go
+++ b/types.go
@@ -152,3 +152,17 @@ type (
 
 	fetchFunc func(user string, maxTweetsNbr int, cursor string) ([]*Tweet, string, error)
 )
+
+type TweetList []Tweet
+
+func (t TweetList) Len() int {
+	return len(t)
+}
+
+func (t TweetList) Less(i, j int) bool {
+	return t[i].TimeParsed.Unix() < t[j].TimeParsed.Unix()
+}
+
+func (t TweetList) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}

--- a/util.go
+++ b/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -193,15 +194,26 @@ func parseTimeline(timeline *timeline) ([]*Tweet, string) {
 
 	var cursor string
 	var orderedTweets []*Tweet
-	if len(timeline.Timeline.Instructions) > 0 {
-		for _, entry := range timeline.Timeline.Instructions[0].AddEntries.Entries {
-			if tweet, ok := tweets[entry.Content.Item.Content.Tweet.ID]; ok {
-				orderedTweets = append(orderedTweets, &tweet)
-			}
-			if entry.Content.Operation.Cursor.CursorType == "Bottom" {
-				cursor = entry.Content.Operation.Cursor.Value
-			}
-		}
+
+	for _, oneTweet := range orderTweetsByTime(tweets) {
+		println(oneTweet.TimeParsed.Unix(), "oneTweet:", oneTweet.Text, oneTweet.ID)
+		tmpTw := oneTweet
+		orderedTweets = append(orderedTweets, &tmpTw)
 	}
+
 	return orderedTweets, cursor
+}
+
+func orderTweetsByTime(tweets map[string]Tweet) TweetList {
+
+	tList := make(TweetList, len(tweets))
+	i := 0
+
+	for _, v := range tweets {
+		tList[i] = v
+		i++
+	}
+
+	sort.Sort(sort.Reverse(tList))
+	return tList
 }


### PR DESCRIPTION
If the purpose of this code is to sort tweets, maybe it can change a litter be... 

If there's anything else, I'm sorry to pull this request.

`if len(timeline.Timeline.Instructions) > 0 {
		for _, entry := range timeline.Timeline.Instructions[0].AddEntries.Entries {
			if tweet, ok := tweets[entry.Content.Item.Content.Tweet.ID]; ok {
				orderedTweets = append(orderedTweets, &tweet)
			}
			if entry.Content.Operation.Cursor.CursorType == "Bottom" {
				cursor = entry.Content.Operation.Cursor.Value
			}
		}`
