### PR TITLE
bug fix? - query gets encoded twice messing it up

### DIFF
--- a/search.go
+++ b/search.go
@@ -28,7 +28,7 @@ func SearchProfiles(ctx context.Context, query string, maxProfilesNbr int) <-cha
 
 // getSearchTimeline gets results for a given search query, via the Twitter frontend API
 func (s *Scraper) getSearchTimeline(query string, maxNbr int, cursor string) (*timeline, error) {
-	query = url.PathEscape(query)
+// 	query = url.PathEscape(query)
 	if maxNbr > 50 {
 		maxNbr = 50
 	}


### PR DESCRIPTION
I found that this line of code is not necessary, and causes the query to get encoded twice leaving excess %20 when decoded