### PR TITLE
Don't replace existing `http.Client`

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -118,14 +118,12 @@ func (s *Scraper) SetProxy(proxyAddr string) error {
 		if err != nil {
 			return err
 		}
-		s.client = &http.Client{
-			Transport: &http.Transport{
-				Proxy:        http.ProxyURL(urlproxy),
-				TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-				DialContext: (&net.Dialer{
-					Timeout: s.client.Timeout,
-				}).DialContext,
-			},
+		s.client.Transport = &http.Transport{
+			Proxy:        http.ProxyURL(urlproxy),
+			TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			DialContext: (&net.Dialer{
+				Timeout: s.client.Timeout,
+			}).DialContext,
 		}
 		return nil
 	}
@@ -141,10 +139,8 @@ func (s *Scraper) SetProxy(proxyAddr string) error {
 		}
 		if contextDialer, ok := dialSocksProxy.(proxy.ContextDialer); ok {
 			dialContext := contextDialer.DialContext
-			s.client = &http.Client{
-				Transport: &http.Transport{
-					DialContext: dialContext,
-				},
+			s.client.Transport = &http.Transport{
+				DialContext: dialContext,
 			}
 		} else {
 			return errors.New("failed type assertion to DialContext")


### PR DESCRIPTION
Currently `Scraper.client` is replaced with a new one when using a proxy, so CookieJar is nil and panics on https://github.com/n0madic/twitter-scraper/blob/2b607217fd1165007e9e2f52fea03b3e0df4e2e3/api.go#L36 where it is used.