### PR TITLE
Add view count to tweets

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -2,6 +2,7 @@ package twitterscraper
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -60,6 +61,10 @@ type timeline struct {
 			QuotedStatusIDStr    string    `json:"quoted_status_id_str"`
 			Time                 time.Time `json:"time"`
 			UserIDStr            string    `json:"user_id_str"`
+			Views                struct {
+				State string `json:"state"`
+				Count string `json:"count"`
+			} `json:"ext_views"`
 		} `json:"tweets"`
 		Users map[string]struct {
 			CreatedAt   string `json:"created_at"`
@@ -194,6 +199,14 @@ func (timeline *timeline) parseTweet(id string) *Tweet {
 		if tweet.RetweetedStatusIDStr != "" {
 			tw.IsRetweet = true
 			tw.RetweetedStatus = timeline.parseTweet(tweet.RetweetedStatusIDStr)
+		}
+
+		if tweet.Views.Count != "" {
+			views, viewsErr := strconv.Atoi(tweet.Views.Count)
+			if viewsErr != nil {
+				views = 0
+			}
+			tw.Views = views
 		}
 
 		for _, pinned := range timeline.GlobalObjects.Users[tweet.UserIDStr].PinnedTweetIdsStr {

--- a/tweets_test.go
+++ b/tweets_test.go
@@ -190,3 +190,30 @@ func TestRetweet(t *testing.T) {
 		}
 	}
 }
+
+func TestTweetViews(t *testing.T) {
+	sample := &twitterscraper.Tweet{
+		HTML:         "Replies and likes don’t tell the whole story. We’re making it easier to tell *just* how many people have seen your Tweets with the addition of view counts, shown right next to likes. Now on iOS and Android, web coming soon.",
+		ID:           "1606055187348688896",
+		Likes:        2839,
+		Name:         "Twitter Support",
+		PermanentURL: "https://twitter.com/TwitterSupport/status/1606055187348688896",
+		Replies:      3427,
+		Retweets:     783,
+		Text:         "Replies and likes don’t tell the whole story. We’re making it easier to tell *just* how many people have seen your Tweets with the addition of view counts, shown right next to likes. Now on iOS and Android, web coming soon.",
+		TimeParsed:   time.Date(2022, 12, 22, 22, 32, 50, 0, time.FixedZone("UTC", 0)),
+		Timestamp:    1612881838,
+		UserID:       "17874544",
+		Username:     "TwitterSupport",
+		Views:        3189278,
+	}
+	scraper := twitterscraper.New()
+	tweet, err := scraper.GetTweet("1606055187348688896")
+	if err != nil {
+		t.Error(err)
+	} else {
+		if tweet.Views < sample.Views {
+			t.Error("Views must be greater than or equal to the sample")
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -50,6 +50,7 @@ type (
 		UserID           string
 		Username         string
 		Videos           []Video
+		Views            int
 		SensitiveContent bool
 	}
 


### PR DESCRIPTION
Tweets after ~22/12/2022 have view info in the json object. Small PR to expose the view count.

```
"<tweet id>": {
    ...
    "retweet_count": <retweet count>,
    "favorite_count": <favorite count>,
    "reply_count": <reply count>,
    "quote_count": <quote count>,
    ...
    "ext_views": { "state": "EnabledWithCount", "count": "<view count>" },
    ...
}
```