### PR TITLE
update auth.go , getFlowToken handle DenyLoginSubtask

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -131,6 +131,8 @@ func (s *Scraper) getFlowToken(data map[string]interface{}) (string, error) {
 			err = fmt.Errorf("auth error: %v", "LoginAcid")
 		} else if info.Subtasks[0].SubtaskID == "LoginTwoFactorAuthChallenge" {
 			err = fmt.Errorf("auth error: %v", "LoginTwoFactorAuthChallenge")
+		} else if info.Subtasks[0].SubtaskID == "DenyLoginSubtask" {
+			err = fmt.Errorf("auth error: %v", "DenyLoginSubtask")
 		}
 	}
 


### PR DESCRIPTION
If login fails many times, Twitter will return this Subtask to reject new login requests, and if this error is not handled properly, the Login function will not return an error, but actually does not login successfully.